### PR TITLE
Simplifying portal code and make it use ReactDOM.createPortal if available

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -1,0 +1,31 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _reactDom = require('react-dom');
+
+var _reactDom2 = _interopRequireDefault(_reactDom);
+
+var _portal = require('./portal');
+
+var _portal2 = _interopRequireDefault(_portal);
+
+var _legacyPortal = require('./legacy-portal');
+
+var _legacyPortal2 = _interopRequireDefault(_legacyPortal);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// eslint-disable-next-line 
+var Portal = void 0;
+
+if (_reactDom2.default.createPortal) {
+  Portal = _portal2.default;
+} else {
+  Portal = _legacyPortal2.default;
+}
+
+exports.default = Portal;
+module.exports = exports['default'];

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,15 @@
+import ReactDOM from 'react-dom';
+
+import PortalR16 from './portal';
+import LegacyPortal from './legacy-portal';
+
+// eslint-disable-next-line 
+let Portal;
+
+if (ReactDOM.createPortal) {
+  Portal = PortalR16;
+} else {
+  Portal = LegacyPortal;
+}
+
+export default Portal;

--- a/lib/legacy-portal.js
+++ b/lib/legacy-portal.js
@@ -1,0 +1,124 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
+
+export default class Portal extends React.PureComponent {
+  static defaultProps = {
+    targetSelector: 'body',
+    onOpen: () => {},
+    onClose: () => {},
+  };
+
+  static propTypes = {
+    children: PropTypes.element.isRequired,
+    targetSelector: PropTypes.string,
+    isOpened: PropTypes.bool,
+    onOpen: PropTypes.func,
+    onClose: PropTypes.func,
+    beforeClose: PropTypes.func,
+    onUpdate: PropTypes.func,
+  };
+
+  constructor() {
+    super();
+    this.state = { active: false };
+    this.closePortal = this.closePortal.bind(this);
+    this.portal = null;
+    this.node = null;
+  }
+
+  componentDidMount() {
+    if (this.props.isOpened) {
+      this.openPortal();
+    }
+  }
+
+  componentWillReceiveProps(newProps) {
+    // portal's 'is open' state is handled through the prop isOpened
+    if (typeof newProps.isOpened !== 'undefined') {
+      if (newProps.isOpened) {
+        if (this.state.active) {
+          this.renderPortal(newProps);
+        } else {
+          this.openPortal(newProps);
+        }
+      }
+      if (!newProps.isOpened && this.state.active) {
+        this.closePortal();
+      }
+    }
+
+    // portal handles its own 'is open' state
+    if (typeof newProps.isOpened === 'undefined' && this.state.active) {
+      this.renderPortal(newProps);
+    }
+  }
+
+  componentWillUnmount() {
+    this.closePortal(true);
+  }
+
+  openPortal(props = this.props) {
+    this.setState({ active: true });
+    this.renderPortal(props);
+    this.props.onOpen(this.node);
+  }
+
+  closePortal(isUnmounted = false) {
+    const resetPortalState = () => {
+      if (this.node) {
+        ReactDOM.unmountComponentAtNode(this.node);
+        const htmlElement = this.targetElement(this.props.targetSelector);
+        htmlElement.removeChild(this.node);
+      }
+      this.portal = null;
+      this.node = null;
+      if (isUnmounted !== true) {
+        this.setState({ active: false });
+      }
+    };
+
+    if (this.state.active) {
+      if (this.props.beforeClose) {
+        this.props.beforeClose(this.node, resetPortalState);
+      } else {
+        resetPortalState();
+      }
+
+      this.props.onClose();
+    }
+  }
+
+  targetElement(targetSelector) {
+    const htmlElement = document.querySelector(targetSelector);
+    if (!htmlElement) {
+      return document.body;
+    }
+    return htmlElement;
+  }
+
+  renderPortal(props) {
+    if (!this.node) {
+      this.node = document.createElement('div');
+      const htmlElement = this.targetElement(props.targetSelector);
+      htmlElement.appendChild(this.node);
+    }
+
+    let children = props.children;
+    // https://gist.github.com/jimfb/d99e0678e9da715ccf6454961ef04d1b
+    if (typeof props.children.type === 'function') {
+      children = React.cloneElement(props.children, { closePortal: this.closePortal });
+    }
+
+    this.portal = ReactDOM.unstable_renderSubtreeIntoContainer(
+      this,
+      children,
+      this.node,
+      this.props.onUpdate
+    );
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -1,10 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactDOM, { findDOMNode } from 'react-dom';
-
-const KEYCODES = {
-  ESCAPE: 27,
-};
+import ReactDOM from 'react-dom';
 
 export default class Portal extends React.PureComponent {
 
@@ -12,133 +8,54 @@ export default class Portal extends React.PureComponent {
     targetSelector: 'body',
     onOpen: () => {},
     onClose: () => {},
-    onUpdate: () => {},
   };
 
   static propTypes = {
     children: PropTypes.element.isRequired,
     targetSelector: PropTypes.string,
-    openByClickOn: PropTypes.element,
-    closeOnEsc: PropTypes.bool,
-    closeOnOutsideClick: PropTypes.bool,
     isOpened: PropTypes.bool,
     onOpen: PropTypes.func,
     onClose: PropTypes.func,
     beforeClose: PropTypes.func,
-    onUpdate: PropTypes.func,
   };
 
   constructor() {
     super();
-    this.state = { active: false };
-    this.handleWrapperClick = this.handleWrapperClick.bind(this);
+    this.state = { active: this.props.isOpened };
     this.closePortal = this.closePortal.bind(this);
-    this.handleOutsideMouseClick = this.handleOutsideMouseClick.bind(this);
-    this.handleKeydown = this.handleKeydown.bind(this);
-    this.portal = null;
     this.node = null;
   }
 
-  componentDidMount() {
-    if (this.props.closeOnEsc) {
-      document.addEventListener('keydown', this.handleKeydown);
-    }
-
-    if (this.props.closeOnOutsideClick) {
-      document.addEventListener('mouseup', this.handleOutsideMouseClick);
-      document.addEventListener('touchstart', this.handleOutsideMouseClick);
-    }
-
-    if (this.props.isOpened) {
-      this.openPortal();
-    }
-  }
-
   componentWillReceiveProps(newProps) {
-    // portal's 'is open' state is handled through the prop isOpened
-    if (typeof newProps.isOpened !== 'undefined') {
+    if (newProps.isOpened !== this.state.active) {
       if (newProps.isOpened) {
-        if (this.state.active) {
-          this.renderPortal(newProps);
-        } else {
-          this.openPortal(newProps);
-        }
-      }
-      if (!newProps.isOpened && this.state.active) {
+        this.openPortal(newProps);
+      } else {
         this.closePortal();
       }
-    }
-
-    // portal handles its own 'is open' state
-    if (typeof newProps.isOpened === 'undefined' && this.state.active) {
-      this.renderPortal(newProps);
     }
   }
 
   componentWillUnmount() {
-    if (this.props.closeOnEsc) {
-      document.removeEventListener('keydown', this.handleKeydown);
+    if (this.node) {
+      const htmlElement = this.targetElement(this.props.targetSelector);
+      htmlElement.removeChild(this.node);
     }
-
-    if (this.props.closeOnOutsideClick) {
-      document.removeEventListener('mouseup', this.handleOutsideMouseClick);
-      document.removeEventListener('touchstart', this.handleOutsideMouseClick);
-    }
-
-    this.closePortal(true);
-  }
-
-  handleWrapperClick(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    if (this.state.active) { return; }
-    this.openPortal();
   }
 
   openPortal(props = this.props) {
     this.setState({ active: true });
-    this.renderPortal(props);
-    this.props.onOpen(this.node);
+    props.onOpen();
   }
 
-  closePortal(isUnmounted = false) {
-    const resetPortalState = () => {
-      if (this.node) {
-        ReactDOM.unmountComponentAtNode(this.node);
-        const htmlElement = this.targetElement(this.props.targetSelector);
-        htmlElement.removeChild(this.node);
-      }
-      this.portal = null;
-      this.node = null;
-      if (isUnmounted !== true) {
-        this.setState({ active: false });
-      }
-    };
-
+  closePortal() {
     if (this.state.active) {
+      this.setState({ active: false });
       if (this.props.beforeClose) {
-        this.props.beforeClose(this.node, resetPortalState);
-      } else {
-        resetPortalState();
+        this.props.beforeClose();
       }
 
       this.props.onClose();
-    }
-  }
-
-  handleOutsideMouseClick(e) {
-    if (!this.state.active) { return; }
-
-    const root = findDOMNode(this.portal);
-    if (root.contains(e.target) || (e.button && e.button !== 0)) { return; }
-
-    e.stopPropagation();
-    this.closePortal();
-  }
-
-  handleKeydown(e) {
-    if (e.keyCode === KEYCODES.ESCAPE && this.state.active) {
-      this.closePortal();
     }
   }
 
@@ -150,31 +67,20 @@ export default class Portal extends React.PureComponent {
     return htmlElement;
   }
 
-  renderPortal(props) {
+  render() {
+    if (!this.state.active) {
+      return null;
+    }
+
     if (!this.node) {
       this.node = document.createElement('div');
-      const htmlElement = this.targetElement(props.targetSelector);
+      const htmlElement = this.targetElement(this.props.targetSelector);
       htmlElement.appendChild(this.node);
     }
 
-    let children = props.children;
-    // https://gist.github.com/jimfb/d99e0678e9da715ccf6454961ef04d1b
-    if (typeof props.children.type === 'function') {
-      children = React.cloneElement(props.children, { closePortal: this.closePortal });
-    }
-
-    this.portal = ReactDOM.unstable_renderSubtreeIntoContainer(
-      this,
-      children,
-      this.node,
-      this.props.onUpdate
+    return ReactDOM.createPortal(
+      this.props.children,
+      this.node
     );
-  }
-
-  render() {
-    if (this.props.openByClickOn) {
-      return React.cloneElement(this.props.openByClickOn, { onClick: this.handleWrapperClick });
-    }
-    return null;
   }
 }

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -19,9 +19,9 @@ export default class Portal extends React.PureComponent {
     beforeClose: PropTypes.func,
   };
 
-  constructor() {
-    super();
-    this.state = { active: this.props.isOpened };
+  constructor(props) {
+    super(props);
+    this.state = { active: props.isOpened };
     this.closePortal = this.closePortal.bind(this);
     this.node = null;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-portal",
-  "version": "2.2.3-jusbrasil",
+  "version": "2.3.1-jusbrasil",
   "description": "React component for transportation of modals, lightboxes, loading bars... to document.body",
   "main": "build/index",
   "files": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-portal",
   "version": "2.2.3-jusbrasil",
   "description": "React component for transportation of modals, lightboxes, loading bars... to document.body",
-  "main": "build/portal",
+  "main": "build/index",
   "files": [
     "*.md",
     "LICENSE",
@@ -17,7 +17,7 @@
   "license": "MIT",
   "scripts": {
     "start": "node devServerIndex.js",
-    "build": "mkdir -p build && babel ./lib/portal.js --out-file ./build/portal.js",
+    "build": "mkdir -p build && babel ./lib --out-dir ./build",
     "build:examples": "npm run clean && npm run build:examples:webpack",
     "build:examples:webpack": "cross-env NODE_ENV=production webpack --config webpack.config.prod.babel.js",
     "clean": "rimraf build",


### PR DESCRIPTION
Using the new createPortal instead of old unstable_renderSubtreeIntoContainer fix the problem of context don't propagate via Portal.
I've check and the removed options (closeOnEsc, closeOnOutsideClick and openByClickOn) were not used.